### PR TITLE
Fix data being cleaned on every upgrade

### DIFF
--- a/Formula/grakn-core.rb
+++ b/Formula/grakn-core.rb
@@ -10,8 +10,16 @@ class GraknCore < Formula
 
   def install
     libexec.install Dir["*"]
+    dbpath = (var/name/"db/")
+    logpath = (var/name/"log/")
+    inreplace libexec/"server/conf/grakn.properties" do |s|
+      s.gsub! "data-dir=server/db/", "data-dir=" + dbpath
+      s.gsub! "log.dirs=./logs/", "log.dirs=" + logpath
+    end
     bin.install libexec/"grakn"
     bin.env_script_all_files(libexec, Language::Java.java_home_env("1.8"))
+    dbpath.mkpath
+    logpath.mkpath
   end
 
   test do


### PR DESCRIPTION
Fix #1 

## What is the goal of this PR?

Previously, every update/reinstall of `grakn-core` formula would lead to cleaning of Grakn data, which is obvously an undesired experience.

## What are the changes implemented in this PR?

On installing, create a separate directory for logs and data and rewrite `grakn.properties` to use them instead of default directories