### PR TITLE
removes warning for deprecated bottle :unneeded

### DIFF
--- a/Formula/grakn-core.rb
+++ b/Formula/grakn-core.rb
@@ -21,8 +21,6 @@ class GraknCore < Formula
   url "https://github.com/graknlabs/grakn/releases/download/2.0.2/grakn-core-all-mac-2.0.2.zip"
   sha256 "7606ad6951d91b2942ea0e2d3349d636e0b1b54c72e1c888be2616aa99fc70d0"
 
-  bottle :unneeded
-
   depends_on "openjdk@11"
 
   def setup_directory(dir)


### PR DESCRIPTION
Fixes this warning:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the graknlabs/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/graknlabs/homebrew-tap/Formula/grakn-core.rb:24
```

Deprecated in June 2021, [see here](https://github.com/Homebrew/brew/pull/11239).

Please review: @vmax @grabl @vaticle-bot 